### PR TITLE
feat: Slack Webhook URL 동적 로딩 기능 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     testImplementation platform('org.junit:junit-bom:5.10.2')
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.mockito:mockito-core:5.10.0'
+
+    // Env
+    implementation 'io.github.cdimascio:java-dotenv:5.2.2'
 }
 
 tasks.named('compileJava') {

--- a/src/main/java/org/sopt/makers/global/exception/message/ErrorMessage.java
+++ b/src/main/java/org/sopt/makers/global/exception/message/ErrorMessage.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorMessage implements BaseErrorCode {
 	// ===== Webhook 관련 오류 =====
+	INVALID_ENV_PARAMETER(400, "환경 변수 입력값이 올바르지 않습니다.", "W4001"),
 	WEBHOOK_URL_NOT_FOUND(500, "Webhook URL을 찾을 수 없습니다.", "W5001"),
 
 	// ===== Slack 및 일반 서비스 오류 =====

--- a/src/main/java/org/sopt/makers/global/exception/unchecked/InvalidEnvParameterException.java
+++ b/src/main/java/org/sopt/makers/global/exception/unchecked/InvalidEnvParameterException.java
@@ -1,0 +1,14 @@
+package org.sopt.makers.global.exception.unchecked;
+
+import org.sopt.makers.global.exception.base.BaseErrorCode;
+
+public class InvalidEnvParameterException extends SentryUncheckedException {
+
+	public InvalidEnvParameterException(BaseErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public static InvalidEnvParameterException from(BaseErrorCode errorCode) {
+		return new InvalidEnvParameterException(errorCode);
+	}
+}

--- a/src/main/java/org/sopt/makers/global/util/EnvUtil.java
+++ b/src/main/java/org/sopt/makers/global/util/EnvUtil.java
@@ -1,6 +1,7 @@
 package org.sopt.makers.global.util;
 
 import org.sopt.makers.global.exception.message.ErrorMessage;
+import org.sopt.makers.global.exception.unchecked.InvalidEnvParameterException;
 import org.sopt.makers.global.exception.unchecked.UnsupportedServiceTypeException;
 import org.sopt.makers.global.exception.unchecked.WebhookUrlNotFoundException;
 
@@ -30,6 +31,11 @@ public final class EnvUtil {
 	 * @throws WebhookUrlNotFoundException 환경 변수를 찾을 수 없는 경우
 	 */
 	public static String getWebhookUrl(String service, String team, String stage, String type) {
+		if (service == null || team == null || stage == null || type == null) {
+			log.error("환경 변수 입력값이 null입니다: service={}, team={}, stage={}, type={}", service, team, stage, type);
+			throw InvalidEnvParameterException.from(ErrorMessage.INVALID_ENV_PARAMETER);
+		}
+
 		String prefix = resolvePrefix(service.toLowerCase());
 		String envKey = String.format("%s%s_%s_%s",
 			prefix,

--- a/src/main/java/org/sopt/makers/global/util/EnvUtil.java
+++ b/src/main/java/org/sopt/makers/global/util/EnvUtil.java
@@ -4,6 +4,7 @@ import org.sopt.makers.global.exception.message.ErrorMessage;
 import org.sopt.makers.global.exception.unchecked.UnsupportedServiceTypeException;
 import org.sopt.makers.global.exception.unchecked.WebhookUrlNotFoundException;
 
+import io.github.cdimascio.dotenv.Dotenv;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +14,9 @@ import lombok.extern.slf4j.Slf4j;
 public final class EnvUtil {
 	private static final String SLACK_WEBHOOK_PREFIX = "SLACK_WEBHOOK_";
 	private static final String DISCORD_WEBHOOK_PREFIX = "DISCORD_WEBHOOK_";
+	private static final Dotenv dotenv = Dotenv.configure()
+		.directory("src/main/resources")  // .env 파일 경로 지정
+		.load();
 
 	/**
 	 * 서비스 유형에 맞는 웹훅 URL 반환
@@ -33,7 +37,7 @@ public final class EnvUtil {
 			stage.toUpperCase(),
 			type.toUpperCase());
 
-		String webhookUrl = System.getenv(envKey);
+		String webhookUrl = dotenv.get(envKey);
 
 		if (webhookUrl == null || webhookUrl.isBlank()) {
 			log.error("Webhook URL을 찾을 수 없습니다: {}", envKey);

--- a/src/test/java/org/sopt/makers/global/util/EnvUtilTest.java
+++ b/src/test/java/org/sopt/makers/global/util/EnvUtilTest.java
@@ -1,0 +1,49 @@
+package org.sopt.makers.global.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.sopt.makers.global.exception.unchecked.WebhookUrlNotFoundException;
+
+class EnvUtilTest {
+
+	private static final String ENV_FILE_PATH = "src/main/resources/.env";
+
+	@BeforeAll
+	static void setUp() throws IOException {
+		// .env 파일을 테스트 전에 생성
+		String content = """
+                SLACK_WEBHOOK_CREW_DEV_BE=https://hooks.slack.com/services/crew/dev/be
+                SLACK_WEBHOOK_APP_PROD_FE=https://hooks.slack.com/services/app/frod/fe
+                """;
+		Files.createDirectories(Paths.get("src/main/resources"));
+		Files.write(Paths.get(ENV_FILE_PATH), content.getBytes());
+	}
+
+	@AfterAll
+	static void tearDown() throws IOException {
+		// 테스트 후 .env 파일 삭제
+		Files.deleteIfExists(Paths.get(ENV_FILE_PATH));
+	}
+
+	@Test
+	void testGetWebhookUrl_valid() {
+		String expectedUrl = "https://hooks.slack.com/services/crew/dev/be";
+		String actualUrl = EnvUtil.getWebhookUrl("slack", "crew", "dev", "be");
+
+		assertEquals(expectedUrl, actualUrl);
+	}
+
+	@Test
+	void testGetWebhookUrl_notFound() {
+		assertThrows(WebhookUrlNotFoundException.class, () ->
+			EnvUtil.getWebhookUrl("slack", "crew", "prod", "be")
+		);
+	}
+}

--- a/src/test/java/org/sopt/makers/global/util/EnvUtilTest.java
+++ b/src/test/java/org/sopt/makers/global/util/EnvUtilTest.java
@@ -5,19 +5,27 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.sopt.makers.global.exception.unchecked.InvalidEnvParameterException;
+import org.sopt.makers.global.exception.unchecked.UnsupportedServiceTypeException;
 import org.sopt.makers.global.exception.unchecked.WebhookUrlNotFoundException;
 
+@DisplayName("EnvUtil 테스트")
 class EnvUtilTest {
 
 	private static final String ENV_FILE_PATH = "src/main/resources/.env";
 
 	@BeforeAll
 	static void setUp() throws IOException {
-		// .env 파일을 테스트 전에 생성
 		String content = """
                 SLACK_WEBHOOK_CREW_DEV_BE=https://hooks.slack.com/services/crew/dev/be
                 SLACK_WEBHOOK_APP_PROD_FE=https://hooks.slack.com/services/app/frod/fe
@@ -28,10 +36,10 @@ class EnvUtilTest {
 
 	@AfterAll
 	static void tearDown() throws IOException {
-		// 테스트 후 .env 파일 삭제
 		Files.deleteIfExists(Paths.get(ENV_FILE_PATH));
 	}
 
+	@DisplayName("정상적인 키로부터 Webhook URL을 가져온다")
 	@Test
 	void testGetWebhookUrl_valid() {
 		String expectedUrl = "https://hooks.slack.com/services/crew/dev/be";
@@ -40,10 +48,51 @@ class EnvUtilTest {
 		assertEquals(expectedUrl, actualUrl);
 	}
 
+	@DisplayName("존재하지 않는 키로 Webhook URL 조회 시 예외를 발생시킨다")
 	@Test
 	void testGetWebhookUrl_notFound() {
 		assertThrows(WebhookUrlNotFoundException.class, () ->
 			EnvUtil.getWebhookUrl("slack", "crew", "prod", "be")
+		);
+	}
+
+	@DisplayName("지원하지 않는 서비스 타입 입력 시 예외를 발생시킨다")
+	@Test
+	void testGetWebhookUrl_unsupportedServiceType() {
+		assertThrows(UnsupportedServiceTypeException.class, () ->
+			EnvUtil.getWebhookUrl("telegram", "crew", "dev", "be")
+		);
+	}
+
+	@DisplayName("null 값이 입력되면 InvalidEnvParameterException을 발생시킨다")
+	@ParameterizedTest(name = "service={0}, team={1}, stage={2}, type={3}")
+	@MethodSource("provideNullParameters")
+	void testGetWebhookUrl_withNullParameters_shouldThrow(String service, String team, String stage, String type) {
+		assertThrows(InvalidEnvParameterException.class, () ->
+			EnvUtil.getWebhookUrl(service, team, stage, type)
+		);
+	}
+
+	@DisplayName("대소문자 구분 없이 키를 인식할 수 있어야 한다")
+	@ParameterizedTest(name = "service={0}, team={1}, stage={2}, type={3}")
+	@CsvSource({
+		"SLACK, CREW, DEV, BE",
+		"slack, crew, dev, be",
+		"SlAcK, CrEw, DeV, Be"
+	})
+	void testGetWebhookUrl_caseInsensitive(String service, String team, String stage, String type) {
+		String expectedUrl = "https://hooks.slack.com/services/crew/dev/be";
+		String actualUrl = EnvUtil.getWebhookUrl(service, team, stage, type);
+
+		assertEquals(expectedUrl, actualUrl);
+	}
+
+	private static Stream<Arguments> provideNullParameters() {
+		return Stream.of(
+			Arguments.of(null, "crew", "dev", "be"),
+			Arguments.of("slack", null, "dev", "be"),
+			Arguments.of("slack", "crew", null, "be"),
+			Arguments.of("slack", "crew", "dev", null)
 		);
 	}
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #3 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- java-dotenv 라이브러리를 추가하여, EnvUtil 클래스에서 환경 변수 조회 시 기존의 System.getenv() 대신 Dotenv를 사용하도록 변경하였습니다.
- Slack Webhook URL 동적 로딩 기능 구현을 완료했습니다.
- 테스트코드에서 Slack Webhook URL 동적 로딩이 작동하는지 확인했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

- None
