### PR TITLE
fix: .env 파일을 로드하도록 수정 완료

### DIFF
--- a/src/main/java/org/sopt/makers/global/util/EnvUtil.java
+++ b/src/main/java/org/sopt/makers/global/util/EnvUtil.java
@@ -15,9 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 public final class EnvUtil {
 	private static final String SLACK_WEBHOOK_PREFIX = "SLACK_WEBHOOK_";
 	private static final String DISCORD_WEBHOOK_PREFIX = "DISCORD_WEBHOOK_";
-	private static final Dotenv dotenv = Dotenv.configure()
-		.directory("src/main/resources")  // .env 파일 경로 지정
-		.load();
+	private static final Dotenv dotenv = Dotenv.configure().load();
 
 	/**
 	 * 서비스 유형에 맞는 웹훅 URL 반환

--- a/src/test/java/org/sopt/makers/global/util/EnvUtilTest.java
+++ b/src/test/java/org/sopt/makers/global/util/EnvUtilTest.java
@@ -43,7 +43,7 @@ class EnvUtilTest {
 	@Test
 	void testGetWebhookUrl_valid() {
 		String expectedUrl = "https://hooks.slack.com/services/crew/dev/be";
-		String actualUrl = EnvUtil.getWebhookUrl("slack", "crew", "dev", "be");
+		String actualUrl = TestEnvUtil.getWebhookUrl("slack", "crew", "dev", "be");
 
 		assertEquals(expectedUrl, actualUrl);
 	}
@@ -52,7 +52,7 @@ class EnvUtilTest {
 	@Test
 	void testGetWebhookUrl_notFound() {
 		WebhookUrlNotFoundException exception = assertThrows(WebhookUrlNotFoundException.class, () ->
-			EnvUtil.getWebhookUrl("slack", "crew", "prod", "be")
+			TestEnvUtil.getWebhookUrl("slack", "crew", "prod", "be")
 		);
 
 		assertTrue(exception.getMessage().contains("Webhook URL을 찾을 수 없습니다."));
@@ -62,7 +62,7 @@ class EnvUtilTest {
 	@Test
 	void testGetWebhookUrl_unsupportedServiceType() {
 		assertThrows(UnsupportedServiceTypeException.class, () ->
-			EnvUtil.getWebhookUrl("telegram", "crew", "dev", "be")
+			TestEnvUtil.getWebhookUrl("telegram", "crew", "dev", "be")
 		);
 	}
 
@@ -71,7 +71,7 @@ class EnvUtilTest {
 	@MethodSource("provideNullParameters")
 	void testGetWebhookUrl_withNullParameters_shouldThrow(String service, String team, String stage, String type) {
 		assertThrows(InvalidEnvParameterException.class, () ->
-			EnvUtil.getWebhookUrl(service, team, stage, type)
+			TestEnvUtil.getWebhookUrl(service, team, stage, type)
 		);
 	}
 
@@ -87,12 +87,12 @@ class EnvUtilTest {
 	})
 	void testGetWebhookUrl_caseInsensitive(String service, String team, String stage, String type) {
 		if (team.equalsIgnoreCase("app")) {
-			String actualUrl = EnvUtil.getWebhookUrl(service, team, stage, type);
+			String actualUrl = TestEnvUtil.getWebhookUrl(service, team, stage, type);
 			assertEquals("https://hooks.slack.com/services/app/prod/fe", actualUrl);
 			return;
 		}
 
-		String actualUrl = EnvUtil.getWebhookUrl(service, team, stage, type);
+		String actualUrl = TestEnvUtil.getWebhookUrl(service, team, stage, type);
 		assertEquals("https://hooks.slack.com/services/crew/dev/be", actualUrl);
 	}
 	private static Stream<Arguments> provideNullParameters() {

--- a/src/test/java/org/sopt/makers/global/util/EnvUtilTest.java
+++ b/src/test/java/org/sopt/makers/global/util/EnvUtilTest.java
@@ -22,7 +22,7 @@ import org.sopt.makers.global.exception.unchecked.WebhookUrlNotFoundException;
 @DisplayName("EnvUtil 테스트")
 class EnvUtilTest {
 
-	private static final String ENV_FILE_PATH = "src/main/resources/.env";
+	private static final String ENV_FILE_PATH = "src/test/resources/.env";
 
 	@BeforeAll
 	static void setUp() throws IOException {
@@ -30,7 +30,7 @@ class EnvUtilTest {
                 SLACK_WEBHOOK_CREW_DEV_BE=https://hooks.slack.com/services/crew/dev/be
                 SLACK_WEBHOOK_APP_PROD_FE=https://hooks.slack.com/services/app/prod/fe
                 """;
-		Files.createDirectories(Paths.get("src/main/resources"));
+		Files.createDirectories(Paths.get("src/test/resources"));
 		Files.write(Paths.get(ENV_FILE_PATH), content.getBytes());
 	}
 

--- a/src/test/java/org/sopt/makers/global/util/TestEnvUtil.java
+++ b/src/test/java/org/sopt/makers/global/util/TestEnvUtil.java
@@ -1,0 +1,56 @@
+package org.sopt.makers.global.util;
+
+import org.sopt.makers.global.exception.message.ErrorMessage;
+import org.sopt.makers.global.exception.unchecked.InvalidEnvParameterException;
+import org.sopt.makers.global.exception.unchecked.UnsupportedServiceTypeException;
+import org.sopt.makers.global.exception.unchecked.WebhookUrlNotFoundException;
+
+import io.github.cdimascio.dotenv.Dotenv;
+
+class TestEnvUtil {
+	private static final String SLACK_WEBHOOK_PREFIX = "SLACK_WEBHOOK_";
+	private static final String DISCORD_WEBHOOK_PREFIX = "DISCORD_WEBHOOK_";
+	private static final Dotenv dotenv = Dotenv.configure()
+		.directory("src/test/resources")
+		.load();
+
+	/**
+	 * 서비스 유형에 맞는 웹훅 URL 반환
+	 *
+	 * @param service 서비스 유형 (slack, discord 등)
+	 * @param team 팀 이름 (crew, app 등)
+	 * @param stage 환경 (dev, prod)
+	 * @param type 서버 유형 (be, fe)
+	 * @return 웹훅 URL
+	 * @throws UnsupportedServiceTypeException 지원하지 않는 서비스 유형인 경우
+	 * @throws WebhookUrlNotFoundException 환경 변수를 찾을 수 없는 경우
+	 */
+	public static String getWebhookUrl(String service, String team, String stage, String type) {
+		if (service == null || team == null || stage == null || type == null) {
+			throw InvalidEnvParameterException.from(ErrorMessage.INVALID_ENV_PARAMETER);
+		}
+
+		String prefix = resolvePrefix(service.toLowerCase());
+		String envKey = String.format("%s%s_%s_%s",
+			prefix,
+			team.toUpperCase(),
+			stage.toUpperCase(),
+			type.toUpperCase());
+
+		String webhookUrl = dotenv.get(envKey);
+
+		if (webhookUrl == null || webhookUrl.isBlank()) {
+			throw new WebhookUrlNotFoundException(ErrorMessage.WEBHOOK_URL_NOT_FOUND);
+		}
+
+		return webhookUrl;
+	}
+
+	private static String resolvePrefix(String service) {
+		return switch (service) {
+			case "slack" -> SLACK_WEBHOOK_PREFIX;
+			case "discord" -> DISCORD_WEBHOOK_PREFIX;
+			default -> throw new UnsupportedServiceTypeException(ErrorMessage.UNSUPPORTED_SERVICE_TYPE);
+		};
+	}
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #7 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
### JAR 파일에서 .env의 위치 확인 후 해당 경로(루트)에서 읽도록 수정
- JAR 빌드 시 src/main/resources/.env 파일은 Gradle 리소스 처리 방식에 따라 JAR 루트 디렉토리로 복사되는 것을 알게되었습니다.
- 이로 인해 JAR 내부 구조에서는 .env가 classpath:/에 위치하게 되며, directory("src/main/resources")로 설정 시 해당 파일을 찾지 못했습니다.
- 따라서  Dotenv.configure().load()로 수정하여 루트 디렉토리에서 .env 파일을 읽도록 수정했습니다.


## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

### 테스트에서 getWebhookUrl 메서드를 호출하며 발생한 문제
- 테스트 코드에서는 .env 파일의 위치를 src/test/resources로 지정하였습니다.
- 그러나 테스트 코드에서 EnvUtil.getWebhookUrl을 호출할 경우, 해당 메서드 내부의 dotenv.get(envKey) 로직은 기본적으로 루트 디렉토리의 .env 파일을 참조하게 되어, 테스트가 실패하는 문제가 발생했습니다.
- 이를 해결하기 위해, EnvUtil과 동일한 로직을 가진 테스트 전용 유틸리티 클래스인 TestEnvUtil을 새로 작성하였고, 해당 클래스에서는 .env 파일의 경로를 src/test/resources로 명시하여 테스트 환경에서도 정상적으로 .env 파일을 읽어올 수 있도록 설정하였습니다.
