### PR TITLE
fix: Slack Webhook의 허용 형식에 맞게 VO 재구성 완료

### DIFF
--- a/src/main/java/org/sopt/makers/dto/SentryEventDetail.java
+++ b/src/main/java/org/sopt/makers/dto/SentryEventDetail.java
@@ -11,7 +11,8 @@ public record SentryEventDetail(
 	String webUrl,
 	String message,
 	String datetime,
-	String level
+	String level,
+	String title
 ) {
 	public static SentryEventDetail from(JsonNode eventNode) {
 		return SentryEventDetail.builder()
@@ -20,6 +21,7 @@ public record SentryEventDetail(
 			.message(eventNode.path("message").asText())
 			.datetime(eventNode.path("datetime").asText())
 			.level(eventNode.path("level").asText())
+			.title(eventNode.path("title").asText())
 			.build();
 	}
 }

--- a/src/main/java/org/sopt/makers/vo/slack/block/HeaderBlock.java
+++ b/src/main/java/org/sopt/makers/vo/slack/block/HeaderBlock.java
@@ -1,14 +1,15 @@
 package org.sopt.makers.vo.slack.block;
 
-import org.sopt.makers.vo.slack.text.Text;
-
 import static org.sopt.makers.global.constant.SlackConstant.*;
+
+import org.sopt.makers.vo.slack.text.PlainText;
+import org.sopt.makers.vo.slack.text.Text;
 
 public record HeaderBlock(
 	String type,
 	Text text
 ) implements Block {
 	public static HeaderBlock newInstance(String text) {
-		return new HeaderBlock(BLOCK_TYPE_HEADER, Text.newPlainInstance(text, true));
+		return new HeaderBlock(BLOCK_TYPE_HEADER, PlainText.newInstance("🚨 " + text, true));
 	}
 }

--- a/src/main/java/org/sopt/makers/vo/slack/block/SectionBlock.java
+++ b/src/main/java/org/sopt/makers/vo/slack/block/SectionBlock.java
@@ -1,9 +1,10 @@
 package org.sopt.makers.vo.slack.block;
 
-import org.sopt.makers.vo.slack.text.Text;
 import static org.sopt.makers.global.constant.SlackConstant.*;
 
 import java.util.List;
+
+import org.sopt.makers.vo.slack.text.Text;
 
 public record SectionBlock(
 	String type,

--- a/src/main/java/org/sopt/makers/vo/slack/element/Button.java
+++ b/src/main/java/org/sopt/makers/vo/slack/element/Button.java
@@ -1,7 +1,9 @@
 package org.sopt.makers.vo.slack.element;
 
-import org.sopt.makers.vo.slack.text.Text;
 import static org.sopt.makers.global.constant.SlackConstant.*;
+
+import org.sopt.makers.vo.slack.text.PlainText;
+import org.sopt.makers.vo.slack.text.Text;
 
 public record Button(
 	String type,
@@ -10,6 +12,6 @@ public record Button(
 	String url
 ) implements Element {
 	public static Button newInstance(String text, String url) {
-		return new Button(ELEMENT_TYPE_BUTTON, Text.newPlainInstance(text, true), STYLE_PRIMARY, url);
+		return new Button(ELEMENT_TYPE_BUTTON, PlainText.newInstance(text, true), STYLE_PRIMARY, url);
 	}
 }

--- a/src/main/java/org/sopt/makers/vo/slack/text/MarkdownText.java
+++ b/src/main/java/org/sopt/makers/vo/slack/text/MarkdownText.java
@@ -1,0 +1,12 @@
+package org.sopt.makers.vo.slack.text;
+
+import static org.sopt.makers.global.constant.SlackConstant.*;
+
+public record MarkdownText(
+	String type,
+	String text
+) implements Text {
+	public static MarkdownText newInstance(String text) {
+		return new MarkdownText(TEXT_TYPE_MARKDOWN, text);
+	}
+}

--- a/src/main/java/org/sopt/makers/vo/slack/text/PlainText.java
+++ b/src/main/java/org/sopt/makers/vo/slack/text/PlainText.java
@@ -1,0 +1,13 @@
+package org.sopt.makers.vo.slack.text;
+
+import static org.sopt.makers.global.constant.SlackConstant.*;
+
+public record PlainText(
+	String type,
+	String text,
+	boolean emoji
+) implements Text {
+	public static PlainText newInstance(String text, boolean emoji) {
+		return new PlainText(TEXT_TYPE_PLAIN, text, emoji);
+	}
+}

--- a/src/main/java/org/sopt/makers/vo/slack/text/Text.java
+++ b/src/main/java/org/sopt/makers/vo/slack/text/Text.java
@@ -1,17 +1,6 @@
 package org.sopt.makers.vo.slack.text;
 
-import static org.sopt.makers.global.constant.SlackConstant.*;
-
-public record Text(
-	String type,
-	String text,
-	boolean emoji
-) {
-	public static Text newPlainInstance(String text, boolean emoji) {
-		return new Text(TEXT_TYPE_PLAIN, text, emoji);
-	}
-
-	public static Text newFieldInstance(String text) {
-		return new Text(TEXT_TYPE_MARKDOWN, text, false);
-	}
+public sealed interface Text permits PlainText, MarkdownText {
+	String type();
+	String text();
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #11 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- Slack 메시지 전송을 위해 VO 구조를 재구성하였습니다.
- 기존의 Text 레코드를 제거하고, Text를 interface로 대체하며, PlainText와 MarkdownText 두 구현체를 새로 도입했습니다.
- 마크다운은 Slack API의 제약으로 인해 emoji 필드를 지원하지 않으므로, 해당 필드를 제거한 MarkdownText 구현체를 도입해 상황에 따라 유연하게 처리할 수 있도록 개선했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

- None
