### PR TITLE
chore: Slack 알림에서 불필요한 Workflow Link 제목 제거 및 리드미 업데이트 완료

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,14 +58,7 @@ jobs:
               "attachments": [{
                 "color": "good",
                 "title": "✅ Lambda 배포 성공",
-                "text": "Sentry Notifier Lambda가 성공적으로 배포되었습니다.",
-                "fields": [
-                  {
-                    "title": "Workflow Link",
-                    "value": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|워크플로우 링크>",
-                    "short": true
-                  }
-                ]
+                "text": "Sentry Notifier Lambda가 성공적으로 배포되었습니다.\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|워크플로우 링크>"
               }]
             }
         env:
@@ -81,14 +74,7 @@ jobs:
               "attachments": [{
                 "color": "danger",
                 "title": "❌ Lambda 배포 실패",
-                "text": "Sentry Notifier Lambda 배포에 실패했습니다.",
-                "fields": [
-                  {
-                    "title": "Workflow Link",
-                    "value": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|워크플로우 링크>",
-                    "short": true
-                  }
-                ]
+                "text": "Sentry Notifier Lambda 배포에 실패했습니다.\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|워크플로우 링크>"
               }]
             }
         env:


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #21 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- Slack 알림에서 불필요한 Workflow Link 제목을 제거하고 Discord 관련 설명 리드미를 작성했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

- None
