### PR TITLE
chore: .env 파일 전체를 하나의 Secret으로 관리하도록 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,7 +24,9 @@ jobs:
       - name: Create .env file
         run: |
           mkdir -p src/main/resources
-          echo "${{ secrets.DOTENV_FILE }}" > src/main/resources/.env
+          printf '%s' "$DOTENV_FILE" > src/main/resources/.env
+        env:
+          DOTENV_FILE: ${{ secrets.DOTENV_FILE }}
 
       - name: Build shadow JAR (default = shadowJar)
         run: ./gradlew build

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,12 +24,7 @@ jobs:
       - name: Create .env file
         run: |
           mkdir -p src/main/resources
-          cat << EOF > src/main/resources/.env
-          SLACK_WEBHOOK_CREW_DEV_BE=${{ secrets.SLACK_WEBHOOK_CREW_DEV_BE }}
-          SLACK_WEBHOOK_CREW_DEV_FE=${{ secrets.SLACK_WEBHOOK_CREW_DEV_FE }}
-          SLACK_WEBHOOK_CREW_PROD_BE=${{ secrets.SLACK_WEBHOOK_CREW_PROD_BE }}
-          SLACK_WEBHOOK_CREW_PROD_FE=${{ secrets.SLACK_WEBHOOK_CREW_PROD_FE }}
-          EOF
+          echo "${{ secrets.DOTENV_FILE }}" > src/main/resources/.env
 
       - name: Build shadow JAR (default = shadowJar)
         run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Create .env file
         run: |
           mkdir -p src/main/resources
-          echo "${{ secrets.DOTENV_FILE }}" > src/main/resources/.env
+          printf '%s' "$DOTENV_FILE" > src/main/resources/.env
+        env:
+          DOTENV_FILE: ${{ secrets.DOTENV_FILE }}
 
       - name: Compile and run test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,7 @@ jobs:
       - name: Create .env file
         run: |
           mkdir -p src/main/resources
-          cat << EOF > src/main/resources/.env
-          SLACK_WEBHOOK_CREW_DEV_BE=${{ secrets.SLACK_WEBHOOK_CREW_DEV_BE }}
-          SLACK_WEBHOOK_CREW_DEV_FE=${{ secrets.SLACK_WEBHOOK_CREW_DEV_FE }}
-          SLACK_WEBHOOK_CREW_PROD_BE=${{ secrets.SLACK_WEBHOOK_CREW_PROD_BE }}
-          SLACK_WEBHOOK_CREW_PROD_FE=${{ secrets.SLACK_WEBHOOK_CREW_PROD_FE }}
-          EOF
+          echo "${{ secrets.DOTENV_FILE }}" > src/main/resources/.env
 
       - name: Compile and run test
         run: |


### PR DESCRIPTION
## Related issue 🛠
- closes #23 

## Work Description ✏️
- GitHub Actions 워크플로우의 환경변수 관리 방식을 개선했습니다.
- 기존에 4개로 분리되어 있던 Slack Webhook Secret(`SLACK_WEBHOOK_CREW_DEV_BE`, `SLACK_WEBHOOK_CREW_DEV_FE`, `SLACK_WEBHOOK_CREW_PROD_BE`, `SLACK_WEBHOOK_CREW_PROD_FE`)을 하나의 `DOTENV_FILE` Secret으로 통합하여 워크플로우 코드를 간소화했습니다.

### 주요 변경사항
- `.env` 파일 생성 로직을 10줄에서 3줄로 단축
- Secret 관리 포인트를 4개에서 1개로 축소
- 환경변수 추가/수정 시 워크플로우 파일 수정 불필요

## Trouble Shooting ⚽️
- None