### PR TITLE
chore: 날짜 파싱 로직 안정성 개선 완료

### DIFF
--- a/src/main/java/org/sopt/makers/service/DiscordNotificationService.java
+++ b/src/main/java/org/sopt/makers/service/DiscordNotificationService.java
@@ -181,8 +181,17 @@ public class DiscordNotificationService implements NotificationService {
 	 * ISO 날짜 포맷팅
 	 */
 	private String formatDateTime(String isoDatetime) {
-		OffsetDateTime utcTime = OffsetDateTime.parse(isoDatetime, DateTimeFormatter.ISO_DATE_TIME);
-		LocalDateTime koreaTime = utcTime.atZoneSameInstant(ZoneId.of(TIMEZONE_SEOUL)).toLocalDateTime();
-		return koreaTime.format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN));
+		if (isoDatetime == null) {
+			return "Unknown Date";
+		}
+
+		try {
+			OffsetDateTime utcTime = OffsetDateTime.parse(isoDatetime, DateTimeFormatter.ISO_DATE_TIME);
+			LocalDateTime koreaTime = utcTime.atZoneSameInstant(ZoneId.of(TIMEZONE_SEOUL)).toLocalDateTime();
+			return koreaTime.format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN));
+		} catch (DateTimeException e) {
+			log.warn("[Date Parsing Failed] rawValue={}", isoDatetime);
+			return isoDatetime;
+		}
 	}
 }

--- a/src/main/java/org/sopt/makers/service/SlackNotificationService.java
+++ b/src/main/java/org/sopt/makers/service/SlackNotificationService.java
@@ -156,8 +156,17 @@ public class SlackNotificationService implements NotificationService {
 	 * ISO 날짜 포맷팅
 	 */
 	private String formatDateTime(String isoDatetime) {
-		OffsetDateTime utcTime = OffsetDateTime.parse(isoDatetime, DateTimeFormatter.ISO_DATE_TIME);
-		LocalDateTime koreaTime = utcTime.atZoneSameInstant(ZoneId.of(TIMEZONE_SEOUL)).toLocalDateTime();
-		return koreaTime.format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN));
+		if (isoDatetime == null) {
+			return "Unknown Date";
+		}
+
+		try {
+			OffsetDateTime utcTime = OffsetDateTime.parse(isoDatetime, DateTimeFormatter.ISO_DATE_TIME);
+			LocalDateTime koreaTime = utcTime.atZoneSameInstant(ZoneId.of(TIMEZONE_SEOUL)).toLocalDateTime();
+			return koreaTime.format(DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN));
+		} catch (DateTimeException e) {
+			log.warn("[Date Parsing Failed] rawValue={}", isoDatetime);
+			return isoDatetime;
+		}
 	}
 }


### PR DESCRIPTION
## Related issue 🛠
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #25
## Work Description ✏️
<!-- 작업 내용을 간단히 소개주세요 -->
- **날짜 파싱 안정성 강화**: Sentry 웹훅의 `datetime` 필드가 `null`이거나 비표준 형식이어서 파싱에 실패할 경우, 알림 전송이 중단되지 않고 원문(`rawValue`)이나 "Unknown Date"로 처리되도록 개선했습니다.
- **리팩토링**: [formatDateTime](cci:1://file:///Users/donghoon/IdeaProjects/sopt/sentry-webhook/src/main/java/org/sopt/makers/service/DiscordNotificationService.java:179:1-195:2) 메서드 내 삼항 연산자를 제거하고, `null` 체크에 Early Return 패턴을 적용하여 코드 가독성을 높였습니다.
## Trouble Shooting ⚽️
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->
- **잠재적 장애 요인 해결**: 기존에는 날짜 파싱 중 `DateTimeException`이 발생하면 알림 전송 트랜잭션 전체가 롤백/실패 처리되어, 정작 중요한 에러 정보를 받아보지 못할 위험이 있었습니다. 이를 Fallback 로직으로 감싸 해결했습니다.